### PR TITLE
Fixed keyboard scroll bug in messages

### DIFF
--- a/qml/components/MessagingBar.qml
+++ b/qml/components/MessagingBar.qml
@@ -32,7 +32,6 @@ Item {
     // Harbour incompatible: QML Qt Quick Controls isn't allowed
     height: timestamp.y + timestamp.height + Theme.paddingSmall
 
-    // Harbour incompatible, needs a workaround for their to restrictive rules
     ThemeEffect {
         id: buttonBuzz
         effect: ThemeEffect.Press
@@ -69,8 +68,8 @@ Item {
                                                       : Theme.primaryColor)
         icon.scale: Theme.iconSizeSmall/icon.width
         onPressed: {
-            buttonBuzz.play()
             send(input.text)
+            buttonBuzz.play()
             input.text = ""
         }
     }

--- a/qml/components/MessagingBar.qml
+++ b/qml/components/MessagingBar.qml
@@ -26,6 +26,7 @@ import QtFeedback 5.0
 Item {
     property string placeHolderText
     signal send(string text)
+    signal keyboardVisible(bool state)
 
     id: messagingBar
     width: parent.width
@@ -54,6 +55,7 @@ Item {
         color: Theme.primaryColor
         placeholderText: messagingBar.placeHolderText
         EnterKey.enabled: text.length > 0
+        onFocusChanged: keyboardVisible(focus) // Workaround for Qt issue: https://bugreports.qt.io/browse/QTBUG-36909
     }
 
     IconButton {

--- a/qml/components/PhotoGridLayout.qml
+++ b/qml/components/PhotoGridLayout.qml
@@ -170,7 +170,9 @@ Item {
 
             IconButton {
                 anchors.centerIn: parent
-                icon.source: "qrc:///images/remove.png"
+                icon.source: "qrc:///images/remove.png" + (pressed
+                                                           ? Theme.highlightColor
+                                                           : Theme.primaryColor)
                 onClicked: {
                     _showRemoveButton = false
                     fullScreen.visible = false

--- a/qml/pages/MessagingPage.qml
+++ b/qml/pages/MessagingPage.qml
@@ -55,6 +55,14 @@ Page {
         }
     }
 
+    Timer {
+        id: keyboardDelay
+        interval: 250 // A wild guess for the duration of the Sailfish OS keyboard
+        running: false
+        repeat: false
+        onTriggered: messagesListView.scrollToBottom()
+    }
+
     MessagingHeader {
         id: messagingHeader
         name: page.name
@@ -95,6 +103,10 @@ Page {
         onSend: {
             busyStatus.running = Qt.application.active
             api.sendMessage(matchId, text, userId, Math.random().toString())
+        }
+        onKeyboardVisible: {
+            console.debug("Keyboard opened? " + state)
+            keyboardDelay.restart() // Make sure we see the latest messages when the keyboard shows/hides
         }
     }
 

--- a/rpm/harbour-sailfinder.changes
+++ b/rpm/harbour-sailfinder.changes
@@ -1,5 +1,6 @@
 * Tue May 10 2018 Dylan Van Assche <dylan.van.assche@protonmail.com> 4.4-4
 - [MINOR BUGFIX] Sailfinder can now run in the emulator again
+- [MINOR BUGFIX] Messages are scrolling automatically when the keyboard shows/hides
 - [IMPROVEMENT] Remorse action used when needed
 - [IMPROVEMENT] Stability improvements for the login screen
 - [IMPROVEMENT] Location updates are still working OK

--- a/rpm/harbour-sailfinder.changes
+++ b/rpm/harbour-sailfinder.changes
@@ -1,7 +1,8 @@
-* Tue May 10 2018 Dylan Van Assche <dylan.van.assche@protonmail.com> 4.4-1
+* Tue May 10 2018 Dylan Van Assche <dylan.van.assche@protonmail.com> 4.4-4
 - [MINOR BUGFIX] Sailfinder can now run in the emulator again
 - [IMPROVEMENT] Remorse action used when needed
 - [IMPROVEMENT] Stability improvements for the login screen
+- [IMPROVEMENT] Location updates are still working OK
 - [NEW] Delete pictures from Tinder (hold a profile picture to show remove screen)
 - [NEW] Opt-in for Smart Photo's
 - [NEW] Moved to OBS for building RPM's

--- a/rpm/harbour-sailfinder.spec
+++ b/rpm/harbour-sailfinder.spec
@@ -14,7 +14,7 @@ Name:       harbour-sailfinder
 %{?qtc_builddir:%define _builddir %qtc_builddir}
 Summary:    Sailfinder
 Version:    4.4
-Release:    2
+Release:    4
 Group:      Qt/Qt
 License:    GPLv3
 URL:        https://github.com/DylanVanAssche/harbour-sailfinder

--- a/rpm/harbour-sailfinder.yaml
+++ b/rpm/harbour-sailfinder.yaml
@@ -1,7 +1,7 @@
 Name: harbour-sailfinder
 Summary: Sailfinder
 Version: 4.4
-Release: 3
+Release: 4
 # The contents of the Group field should be one of the groups listed here:
 # http://gitorious.org/meego-developer-tools/spectacle/blobs/master/data/GROUPS
 Group: Qt/Qt


### PR DESCRIPTION
1. **Explanation**: 
    - Messages are scrolling now automatically when the keyboard shows/hides. This PR circumvents the internal Qt bug mentioned in #137 

2. **Fixed issues**: 
    - Fixed #137 

3. **Testing environment**: 
    - Sailfish OS version: 2.1.4.11
    - Sailfish OS hardware: Jolla 1
