### PR TITLE
Match profile isn't empty any more after sending message

### DIFF
--- a/qml/components/MessagingBar.qml
+++ b/qml/components/MessagingBar.qml
@@ -53,7 +53,7 @@ Item {
             top: parent.top
         }
         width: Theme.itemSizeMedium
-        height: Math.min(Theme.itemSizeMedium, parent.height)
+        height: parent.height
 
         Label {
             anchors.centerIn: parent

--- a/qml/pages/MessagingPage.qml
+++ b/qml/pages/MessagingPage.qml
@@ -30,7 +30,7 @@ Page {
     property string matchId
     property string userId
     property int distance
-    property var match // Until full profile API is added, fetching profile depends then on the matchId
+    property var match
 
     Component.onCompleted: api.getMessages(matchId)
 
@@ -102,7 +102,9 @@ Page {
         placeHolderText: qsTrId("sailfinder-messaging-placeholder").arg(name)
         onSendText: {
             busyStatus.running = Qt.application.active
+            console.debug("NOT EMPTY=" + match)
             api.sendMessage(matchId, text, userId, Math.random().toString())
+            console.debug("EMPTY=" + match)
         }
         onSendGIF: {
             busyStatus.running = Qt.application.active

--- a/rpm/harbour-sailfinder.changes
+++ b/rpm/harbour-sailfinder.changes
@@ -1,6 +1,7 @@
-* Thu May 24 2018 Dylan Van Assche <dylan.van.assche@protonmail.com> 4.5-2
+* Thu May 24 2018 Dylan Van Assche <dylan.van.assche@protonmail.com> 4.5-3
 - [MINOR BUGFIX] Cover showed 'Exhausted' when launching
 - [MINOR BUGFIX] Search distance is now limited to 100 km instead of 160 miles
+- [MINOR BUGFIX] Match profile isn't empty anymore after sending a message
 - [MAJOR BUGFIX] Fixed translations files in .pro files, they should now be loaded correctly
 - [IMPROVEMENT] Image loading on mobile networks and ethernet has been improved
 - [NEW] Show GIF's in messages

--- a/rpm/harbour-sailfinder.spec
+++ b/rpm/harbour-sailfinder.spec
@@ -9,7 +9,7 @@ Name:       harbour-sailfinder
 %{?qtc_builddir:%define _builddir %qtc_builddir}
 Summary:    Sailfinder
 Version:    4.5
-Release:    2
+Release:    3
 Group:      Qt/Qt
 License:    GPLv3
 URL:        https://github.com/DylanVanAssche/harbour-sailfinder

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1738,7 +1738,6 @@ void API::parseSendMessage(QJsonObject json)
 
     // Enforce view updates
     emit this->newMessage(0);
-    this->matchesList()->updateMatchLastMessage(json["match_id"].toString(), newMessage);
 
     // Unlock send messages
     messagesSendLock = false;

--- a/src/models/matcheslistmodel.cpp
+++ b/src/models/matcheslistmodel.cpp
@@ -136,19 +136,6 @@ void MatchesListModel::setMatchesList(const QList<Match *> &matchesList)
     emit this->endResetModel();
 }
 
-void MatchesListModel::updateMatchLastMessage(const QString &matchId, Message *lastMessage)
-{
-    this->beginResetModel(); // Enforce view update
-    foreach(Match* match, this->matchesList()) {
-        if(match->matchId() == matchId) {
-            match->setMessage(lastMessage);
-            qDebug() << "Last message has been updated";
-            break;
-        }
-    }
-    this->endResetModel();
-}
-
 int MatchesListModel::numberOfMatches()
 {
     return this->matchesList().count();

--- a/src/models/matcheslistmodel.h
+++ b/src/models/matcheslistmodel.h
@@ -57,7 +57,6 @@ class MatchesListModel : public QAbstractListModel
         virtual QVariant data(const QModelIndex &index, int role) const;
         QList<Match *> matchesList() const;
         void setMatchesList(const QList<Match *> &matchesList);
-        void updateMatchLastMessage(const QString &matchId, Message* lastMessage);
         Q_INVOKABLE int numberOfMatches();
 
 protected:


### PR DESCRIPTION
1. **Explanation**: 
    - Match profile isn't empty any more after sending message

2. **Fixed issues**: 
    - Fixed #181 

3. **Testing environment**: 
    - Sailfish OS version: 2.2.0.29
    - Sailfish OS hardware: Xperia X
