### PR TITLE
GIF page now works on low power devices like the Jolla 1

### DIFF
--- a/qml/pages/GIFPage.qml
+++ b/qml/pages/GIFPage.qml
@@ -83,18 +83,20 @@ Page {
             Grid {
                 id: grid
                 width: parent.width
-                columns: 3
+                columns: 2
 
                 Repeater {
                     id: gridModel
 
                     AnimatedImage {
+                        id: gif
                         property bool _loadingGif: true
 
                         width: grid.width / grid.columns
                         height: width
                         source: model.url
                         asynchronous: true
+                        paused: true // too heavy for low power devices like the Jolla 1
                         onProgressChanged: _loadingGif = (progress < 1.0)
 
                         MouseArea {
@@ -117,6 +119,14 @@ Page {
                             anchors.centerIn: parent
                             size: BusyIndicatorSize.Medium
                             running: Qt.application.active && parent._loadingGif
+                        }
+
+                        IconButton {
+                            anchors.centerIn: parent
+                            z: 1 // visible above GIF
+                            icon.source: gif.paused? "image://theme/icon-l-play": "image://theme/icon-l-pause"
+                            onClicked: gif.paused? gif.paused = false: gif.paused = true
+                            visible: !gif._loadingGif
                         }
                     }
                 }

--- a/rpm/harbour-sailfinder.changes
+++ b/rpm/harbour-sailfinder.changes
@@ -1,4 +1,4 @@
-* Thu May 24 2018 Dylan Van Assche <dylan.van.assche@protonmail.com> 4.5-3
+* Thu May 24 2018 Dylan Van Assche <dylan.van.assche@protonmail.com> 4.5-4
 - [MINOR BUGFIX] Cover showed 'Exhausted' when launching
 - [MINOR BUGFIX] Search distance is now limited to 100 km instead of 160 miles
 - [MINOR BUGFIX] Match profile isn't empty anymore after sending a message

--- a/rpm/harbour-sailfinder.changes
+++ b/rpm/harbour-sailfinder.changes
@@ -2,6 +2,7 @@
 - [MINOR BUGFIX] Cover showed 'Exhausted' when launching
 - [MINOR BUGFIX] Search distance is now limited to 100 km instead of 160 miles
 - [MINOR BUGFIX] Match profile isn't empty anymore after sending a message
+- [MAJOR BUGFIX] GIF page works now on low power devices like the Jolla 1
 - [MAJOR BUGFIX] Fixed translations files in .pro files, they should now be loaded correctly
 - [IMPROVEMENT] Image loading on mobile networks and ethernet has been improved
 - [NEW] Show GIF's in messages

--- a/rpm/harbour-sailfinder.spec
+++ b/rpm/harbour-sailfinder.spec
@@ -9,7 +9,7 @@ Name:       harbour-sailfinder
 %{?qtc_builddir:%define _builddir %qtc_builddir}
 Summary:    Sailfinder
 Version:    4.5
-Release:    3
+Release:    4
 Group:      Qt/Qt
 License:    GPLv3
 URL:        https://github.com/DylanVanAssche/harbour-sailfinder


### PR DESCRIPTION
1. **Explanation**: 
    - GIF page now works on low power devices like the Jolla 1

2. **Fixed issues**: 
    - Fixed #188 

3. **Testing environment**: 
    - Sailfish OS version: 2.2.0.29
    - Sailfish OS hardware: Xperia X and Jolla 1
